### PR TITLE
fixes issue were images are not removed from queue

### DIFF
--- a/js/rimd.js
+++ b/js/rimd.js
@@ -509,13 +509,12 @@
 				}
 			}
 
+			removeFromQueue();
+			
 			if(!lazyload || isElementInViewport(elem)) {
 				img.src = src;
 				elem.appendChild(img);
 			} else {
-
-				removeFromQueue();
-
 				lazyQueue.push({
 					id: id,
 					e: elem,


### PR DESCRIPTION
moving removeFromQUeue(); outside the if-statement removes the duplicate image bug when pictures are appended, when they're not lazyloading or inside the viewport.